### PR TITLE
Updated TLA+2 BNF grammar spec to better conform with language standard

### DIFF
--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -149,8 +149,6 @@ TLAPlusGrammar ==
    /\ G.OpOrExpression ::=
           PrefixOp | InfixOp | PostfixOp | G.Lambda | G.Expression
 
-   /\ G.Argument ::= G.Expression  | G.Opname | G.Lambda
-
    /\ G.Lambda ::= tok("LAMBDA") & CommaList(Identifier) 
                      & tok(":") & G.Expression
 
@@ -161,7 +159,7 @@ TLAPlusGrammar ==
               | Tok({"<<", ">>", "@"} \cup Numeral^+) )
         )^*
 
-   /\ G.OpArgs ::= tok("(") & CommaList(G.Argument) & tok(")")
+   /\ G.OpArgs ::= tok("(") & CommaList(G.OpOrExpression) & tok(")")
 
    /\ G.InstOrSubexprPrefix ::=  
       (    (Nil | ProofStepId & tok("!")) 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -154,18 +154,23 @@ TLAPlusGrammar ==
 
    /\ G.OpArgs ::= tok("(") & CommaList(G.OpOrExpression) & tok(")")
 
-   /\ G.InstOrSubexprPrefix ::=  
-      (    (Nil | ProofStepId & tok("!")) 
-        & ( (   Identifier & (Nil | G.OpArgs)
-              | Tok({"<<", ">>", ":"} \cup Numeral^+)
-              | G.OpArgs 
-              | (PrefixOp | PostfixOp) & tok("(") & G.Expression & tok(")")
-              | InfixOp & tok("(") & G.Expression & tok(",") 
-                  & G.Expression & tok(")")
-             )
-            &  tok("!")
-          ) ^*
-      ) \ Nil
+   /\ G.InstOrSubexprPrefix ::=
+           (G.SubexprComponent | ProofStepId) & tok("!")
+        &  ((G.SubexprComponent | G.SubexprTreeNav) & tok("!"))^*
+   
+   /\ G.SubexprComponent ::=
+           Identifier & (Nil | G.OpArgs)
+        |  PrefixOp & tok("(") & G.Expression & tok(")")
+        |  InfixOp & tok("(") & G.Expression & tok(",")
+             & G.Expression & tok(")")
+        |  PostfixOp & tok("(") & G.Expression & tok(")")
+        |  PrefixOp
+        |  InfixOp
+        |  PostfixOp
+
+   /\ G.SubexprTreeNav ::=
+           Tok({"<<", ">>", ":", "@"} \cup Numeral^+)
+        |  G.OpArgs
 
 \* /\ G.InstancePrefix ::= ...
 
@@ -266,9 +271,7 @@ TLAPlusGrammar ==
             Name & (Nil | tok("(") & CommaList(Identifier) & tok(")")) 
                & tok("::") & G.Expression
 
-         |  G.InstOrSubexprPrefix 
-               & (Tok({"<<", ">>", ":"} \cup Numeral^+) | G.OpArgs)
-
+         |  G.InstOrSubexprPrefix & G.SubexprTreeNav
 
          |  G.GeneralIdentifier & (Nil | G.OpArgs)
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -152,13 +152,6 @@ TLAPlusGrammar ==
    /\ G.Lambda ::= tok("LAMBDA") & CommaList(Identifier) 
                      & tok(":") & G.Expression
 
-   /\ G.OpName ::= 
-        (Identifier | PrefixOp | InfixOp | PostfixOp | ProofStepId)
-      & (  tok("!")
-         & (Identifier | PrefixOp | InfixOp | PostfixOp
-              | Tok({"<<", ">>", "@"} \cup Numeral^+) )
-        )^*
-
    /\ G.OpArgs ::= tok("(") & CommaList(G.OpOrExpression) & tok(")")
 
    /\ G.InstOrSubexprPrefix ::=  
@@ -261,7 +254,7 @@ TLAPlusGrammar ==
 
    /\ G.UseBody  ::=  (  (Nil | CommaList(G.Expression | tok("MODULE") & Name ))
                        & (Nil | Tok({"DEF", "DEFS"}) 
-                                  & CommaList(G.OpName | 
+                                  & CommaList(G.OpOrExpression | 
                                                 tok("MODULE") & Name ))
                       ) \ Nil
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -165,14 +165,19 @@ TLAPlusGrammar ==
         &  ((G.SubexprComponent | G.SubexprTreeNav) & tok("!"))^*
    
    /\ G.SubexprComponent ::=
-           Identifier & (Nil | G.OpArgs)
-        |  StandalonePrefixOp & tok("(") & G.Expression & tok(")")
-        |  InfixOp & tok("(") & G.Expression & tok(",")
-             & G.Expression & tok(")")
-        |  PostfixOp & tok("(") & G.Expression & tok(")")
+           G.BoundOp
+        |  G.BoundNonfixOp
         |  StandalonePrefixOp
         |  InfixOp
         |  PostfixOp
+
+   /\ G.BoundOp ::= Identifier & (Nil | G.OpArgs)
+
+   /\ G.BoundNonfixOp ::=
+           StandalonePrefixOp & tok("(") & G.Expression & tok(")")
+        |  InfixOp & tok("(") & G.Expression & tok(",")
+             & G.Expression & tok(")")
+        |  PostfixOp & tok("(") & G.Expression & tok(")")
 
    /\ G.SubexprTreeNav ::=
            Tok({"<<", ">>", ":", "@"} \cup Numeral^+)
@@ -182,8 +187,7 @@ TLAPlusGrammar ==
 
    /\ G.GeneralIdentifier ::=
            (Nil | G.InstOrSubexprPrefix)
-        &  Identifier
-        &  (Nil | G.OpArgs)
+        &  (G.BoundOp | G.BoundNonfixOp)
 
 \* /\ G.GeneralIdentifier ::= ...
 \* /\ G.GeneralPrefixOp   ::= ...
@@ -269,7 +273,6 @@ TLAPlusGrammar ==
                                   & CommaList(G.OpOrExpression | 
                                                 tok("MODULE") & Name ))
                       ) \ Nil
-
 
    /\ G.Expression ::= 
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -112,6 +112,7 @@ TLAPlusGrammar ==
                      |  PrefixOp & tok("_")
                      |  tok("_") & InfixOp & tok("_")
                      |  tok("_") & PostfixOp  
+
    /\  G.OperatorDefinition ::=  
             (   G.NonFixLHS 
              |  PrefixOp   & Identifier 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -146,7 +146,10 @@ TLAPlusGrammar ==
    /\ G.Substitution ::=  
              (Identifier | PrefixOp | InfixOp | PostfixOp ) 
           &  tok("<-") 
-          &  G.Argument  
+          &  G.OpOrExpression 
+
+   /\ G.OpOrExpression ::=
+          PrefixOp | InfixOp | PostfixOp | G.Lambda | G.Expression
 
    /\ G.Argument ::= G.Expression  | G.Opname | G.Lambda
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -49,9 +49,15 @@ BeginStepToken == Tok({"<"} & (Numeral^+ | {"*", "+"}) & {">"} &
 
 String == Tok({"\""} & STRING & {"\""})
 
+PrefixOpExceptNegative ==
+  { "~", "\\lnot", "\\neg", "[]", "<>",
+    "DOMAIN",  "ENABLED", "SUBSET", "UNCHANGED", "UNION"}
+
+StandalonePrefixOp ==
+  Tok(PrefixOpExceptNegative \cup {"-."})
+
 PrefixOp  ==  
-  Tok({ "-", "~", "\\lnot", "\\neg", "[]", "<>",
-        "DOMAIN",  "ENABLED", "SUBSET", "UNCHANGED", "UNION"})
+  Tok(PrefixOpExceptNegative \cup {"-"})
 
 InfixOp   ==
   Tok({  "!!",  "#",    "##",   "$",    "$$",   "%",    "%%",  
@@ -109,13 +115,13 @@ TLAPlusGrammar ==
    /\ G.OpDecl ::=      Identifier 
                      |  Identifier & tok("(") & 
                                CommaList(tok("_")) & tok(")")
-                     |  PrefixOp & tok("_")
+                     |  StandalonePrefixOp & tok("_")
                      |  tok("_") & InfixOp & tok("_")
                      |  tok("_") & PostfixOp  
 
    /\  G.OperatorDefinition ::=  
             (   G.NonFixLHS 
-             |  PrefixOp   & Identifier 
+             |  StandalonePrefixOp   & Identifier 
              |  Identifier & InfixOp & Identifier 
              |  Identifier & PostfixOp )
           &  tok("==") 
@@ -142,12 +148,12 @@ TLAPlusGrammar ==
         &  (Nil | tok("WITH") & CommaList(G.Substitution))  
 
    /\ G.Substitution ::=  
-             (Identifier | PrefixOp | InfixOp | PostfixOp ) 
+             (Identifier | StandalonePrefixOp | InfixOp | PostfixOp ) 
           &  tok("<-") 
           &  G.OpOrExpression 
 
    /\ G.OpOrExpression ::=
-          PrefixOp | InfixOp | PostfixOp | G.Lambda | G.Expression
+          StandalonePrefixOp | InfixOp | PostfixOp | G.Lambda | G.Expression
 
    /\ G.Lambda ::= tok("LAMBDA") & CommaList(Identifier) 
                      & tok(":") & G.Expression
@@ -160,11 +166,11 @@ TLAPlusGrammar ==
    
    /\ G.SubexprComponent ::=
            Identifier & (Nil | G.OpArgs)
-        |  PrefixOp & tok("(") & G.Expression & tok(")")
+        |  StandalonePrefixOp & tok("(") & G.Expression & tok(")")
         |  InfixOp & tok("(") & G.Expression & tok(",")
              & G.Expression & tok(")")
         |  PostfixOp & tok("(") & G.Expression & tok(")")
-        |  PrefixOp
+        |  StandalonePrefixOp
         |  InfixOp
         |  PostfixOp
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -180,9 +180,10 @@ TLAPlusGrammar ==
 
 \* /\ G.InstancePrefix ::= ...
 
-   /\ G.GeneralIdentifier ::= 
-           (G.InstOrSubexprPrefix | Nil) & Identifier 
-         | ProofStepId
+   /\ G.GeneralIdentifier ::=
+           (Nil | G.InstOrSubexprPrefix)
+        &  Identifier
+        &  (Nil | G.OpArgs)
 
 \* /\ G.GeneralIdentifier ::= ...
 \* /\ G.GeneralPrefixOp   ::= ...
@@ -279,7 +280,9 @@ TLAPlusGrammar ==
 
          |  G.InstOrSubexprPrefix & G.SubexprTreeNav
 
-         |  G.GeneralIdentifier & (Nil | G.OpArgs)
+         |  G.GeneralIdentifier
+
+         |  ProofStepId
 
          |  PrefixOp & G.Expression 
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -42,7 +42,7 @@ NumberLexeme ==
 
 Number == Tok(NumberLexeme)
 
-ProofStepId == Tok({"<"} & (Numeral^+ | {"*"}) & {">"} & (Letter | Numeral | {"_"})^+)
+ProofStepId == Tok({"<"} & (Numeral^+ | {"*"}) & {">"} & (Letter | Numeral)^+)
 
 BeginStepToken == Tok({"<"} & (Numeral^+ | {"*", "+"}) & {">"} & 
                        (Letter | Numeral)^* & {"."}^* )

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -383,7 +383,8 @@ TLAPlusGrammar ==
      |        tok("LET") 
            &  (    G.OperatorDefinition 
                 |  G.FunctionDefinition 
-                |  G.ModuleDefinition)^+ 
+                |  G.ModuleDefinition
+                |  G.Recursive)^+
            &  tok("IN") 
            &  G.Expression
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -123,10 +123,7 @@ TLAPlusGrammar ==
 
    /\ G.NonFixLHS ::=   
              Identifier 
-          &  (    Nil 
-              |   tok("(") 
-                & CommaList(Identifier |  G.OpDecl) 
-                & tok(")") ) 
+          &  ( Nil | tok("(") & CommaList(G.OpDecl) & tok(")") )
 
    /\ G.FunctionDefinition ::=   
            Identifier  


### PR DESCRIPTION
These changes fix numerous issues with the existing TLA+2 BNF grammar spec, backporting a number of changes from the SANY parser and adding some missing rules. Changelist:

1. Allowed use of `RECURSIVE` operator declarations inside `LET-IN` constructs
1. Removed underscore from allowed characters in `ProofStepId`
    * NOTE: this was in error, underscores are allowed; change was later made to define valid characters as `NameChar`, see https://github.com/tlaplus-community/tlaplus-standard/commit/6ea0b86b7df4c75471bc9e94b18f370b9f958edc
1. Made large changes to `InstOrSubexprPrefix` rule to match SANY functioning
1. Encoded when to use `-` vs `-.` for the negative prefix operator
1. Separated `ProofStepId` from `GeneralIdentifier` rule
1. Added nonfix operators, for example `+(1,2)`
1. Removed `USE ONLY` as valid syntax; see tlaplus/rfcs#23