### PR TITLE
Updated TLA+2 BNF grammar spec to better conform with language standard, including subexpressions

### DIFF
--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -149,8 +149,6 @@ TLAPlusGrammar ==
    /\ G.OpOrExpression ::=
           PrefixOp | InfixOp | PostfixOp | G.Lambda | G.Expression
 
-   /\ G.Argument ::= G.Expression  | G.Opname | G.Lambda
-
    /\ G.Lambda ::= tok("LAMBDA") & CommaList(Identifier) 
                      & tok(":") & G.Expression
 
@@ -161,7 +159,7 @@ TLAPlusGrammar ==
               | Tok({"<<", ">>", "@"} \cup Numeral^+) )
         )^*
 
-   /\ G.OpArgs ::= tok("(") & CommaList(G.Argument) & tok(")")
+   /\ G.OpArgs ::= tok("(") & CommaList(G.OpOrExpression) & tok(")")
 
    /\ G.InstOrSubexprPrefix ::=  
       (    (Nil | ProofStepId & tok("!")) 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -274,133 +274,181 @@ TLAPlusGrammar ==
                                                 tok("MODULE") & Name ))
                       ) \ Nil
 
-   /\ G.Expression ::= 
-
-\*          G.GeneralIdentifier
-
-            Name & (Nil | tok("(") & CommaList(Identifier) & tok(")")) 
-               & tok("::") & G.Expression
-
+   /\ G.Expression ::=
+            G.Label
          |  G.InstOrSubexprPrefix & G.SubexprTreeNav
-
          |  G.GeneralIdentifier
-
          |  ProofStepId
-
-         |  PrefixOp & G.Expression 
-
-         |  G.Expression & InfixOp & G.Expression 
-
+         |  PrefixOp & G.Expression
+         |  G.Expression & InfixOp & G.Expression
          |  G.Expression & PostfixOp
+         |  G.Parentheses
+         |  G.BoundedQuantification
+         |  G.UnboundedQuantification
+         |  G.Choose
+         |  G.SetLiteral
+         |  G.SetFilter
+         |  G.SetMap
+         |  G.FunctionApplication
+         |  G.FunctionLiteral
+         |  G.FunctionSet
+         |  G.RecordLiteral
+         |  G.RecordSet
+         |  G.Except
+         |  G.RecordValue
+         |  G.TupleLiteral
+         |  G.CartesianProduct
+         |  G.StepExpressionOrStutter
+         |  G.StepExpressionNoStutter
+         |  G.Fairness
+         |  G.IfThenElse
+         |  G.Case
+         |  G.LetIn
+         |  G.ConjunctionList
+         |  G.DisjunctionList
+         |  Number
+         |  String
+         |  tok("@")
 
-         |  tok("(") & G.Expression & tok(")") 
+   /\ G.SubscriptExpression ::=
+            G.GeneralIdentifier
+         |  G.Parenthesis
+         |  G.SetLiteral
+         |  G.SetFilter
+         |  G.SetMap
+         |  G.FunctionLiteral
+         |  G.FunctionSet
+         |  G.RecordLiteral
+         |  G.RecordSet
+         |  G.Except
+         |  G.TupleLiteral
+         |  G.StepExpressionOrStutter
+         |  G.StepExpressionNoStutter
 
-         |   Tok({"\\A", "\\E"}) 
-           & CommaList(G.QuantifierBound)   
-           & tok(":") 
-           & G.Expression 
+   /\ G.Label ::=
+            Name & (Nil | tok("(") & CommaList(Identifier) & tok(")"))
+         &  tok("::") & G.Expression
 
-         |    Tok({"\\A", "\\E", "\\AA", "\\EE"})
-           &  CommaList(Identifier) 
-           &  tok(":") 
-           &  G.Expression 
+   /\ G.Parentheses ::= tok("(") & G.Expression & tok(")")
 
-        |     tok("CHOOSE") 
-           &  IdentifierOrTuple 
-           &  (Nil | tok("\\in") & G.Expression) 
-           &  tok(":") 
-           &  G.Expression 
+   /\ G.BoundedQuantification ::=
+            Tok({"\\A", "\\E"})
+         &  CommaList(G.QuantifierBound)
+         &  tok(":")
+         &  G.Expression
 
-        |     tok("{")
-           & (Nil | CommaList(G.Expression))
-           & tok("}") 
+   /\ G.UnboundedQuantification ::=
+            Tok({"\\A", "\\E", "\\AA", "\\EE"})
+         &  CommaList(Identifier)
+         &  tok(":")
+         &  G.Expression
 
-        |     tok("{") 
-           &  IdentifierOrTuple & tok("\\in") & G.Expression 
-           &  tok(":") 
-           &  G.Expression 
-           &  tok("}") 
+   /\ G.Choose ::=
+            tok("CHOOSE")
+         &  IdentifierOrTuple
+         &  (Nil | tok("\\in") & G.Expression)
+         &  tok(":")
+         &  G.Expression
 
-        |     tok("{") 
-           &  G.Expression  
-           &  tok(":")  
-           &  CommaList(G.QuantifierBound) 
-           &  tok("}") 
+   /\ G.SetLiteral ::=
+            tok("{")
+         &  (Nil | CommaList(G.Expression))
+         &  tok("}")
 
-        |  G.Expression & tok("[") & CommaList(G.Expression)
-             & tok("]")
+   /\ G.SetFilter ::=
+            tok("{")
+         &  IdentifierOrTuple & tok("\\in") & G.Expression
+         &  tok(":")
+         &  G.Expression
+         &  tok("}")
 
-        |     tok("[") 
-           &  CommaList(G.QuantifierBound)
-           &  tok("|->")  
-           &  G.Expression 
-           &  tok("]") 
+   /\ G.SetMap ::=
+            tok("{")
+         &  G.Expression
+         &  tok(":")
+         &  CommaList(G.QuantifierBound)
+         &  tok("}")
 
-       |  tok("[") & G.Expression & tok("->") 
-                 & G.Expression & tok("]") 
+   /\ G.FunctionApplication ::=
+            G.Expression
+         &  tok("[") & CommaList(G.Expression) & tok("]")
 
-       |     tok("[") 
-           & CommaList(Name & tok("|->") & G.Expression) 
-           & tok("]") 
+   /\ G.FunctionLiteral ::=
+            tok("[")
+         &  CommaList(G.QuantifierBound)
+         &  tok("|->")
+         &  G.Expression
+         &  tok("]")
 
-       |     tok("[") 
-           & CommaList(Name & tok(":") & G.Expression)  
-           & tok("]") 
+   /\ G.FunctionSet ::=
+            tok("[")
+         &  G.Expression & tok("->")
+         &  G.Expression & tok("]")
 
-       |      tok("[") 
-           &  G.Expression 
-           &  tok("EXCEPT") 
-           &  CommaList(    tok("!")
-                         & ( tok(".") & Name 
-                             |  tok("[") & CommaList(G.Expression) & tok("]") )^+ 
-                         &  tok("=") & G.Expression ) 
-           &  tok("]") 
+   /\ G.RecordLiteral ::=
+            tok("[")
+         &  CommaList(Name & tok("|->") & G.Expression)
+         &  tok("]")
 
-      |  G.Expression & tok(".") & Name
+   /\ G.RecordSet ::=
+            tok("[")
+         &  CommaList(Name & tok(":") & G.Expression)
+         &  tok("]")
 
-      |  tok("<<") & (CommaList(G.Expression) | Nil) & tok(">>") 
+   /\ G.Except ::=
+            tok("[")
+         &  G.Expression
+         &  tok("EXCEPT")
+         &  CommaList(
+                  tok("!")
+               &  ( tok(".") & Name
+                    |  tok("[") & CommaList(G.Expression) & tok("]") )^+
+               &  tok("=") & G.Expression )
+         &  tok("]")
 
-      |  G.Expression & (Tok({"\\X", "\\times"}) 
-              & G.Expression)^+ 
+   /\ G.RecordValue ::= G.Expression & tok(".") & Name
 
-      |  tok("[")  & G.Expression & tok("]_")  
-           & G.Expression 
+   /\ G.TupleLiteral ::=
+            tok("<<") & (Nil | CommaList(G.Expression)) & tok(">>")
 
-      | tok("<<") & G.Expression & tok(">>_") & G.Expression 
+   /\ G.CartesianProduct ::=
+            G.Expression
+         &  (Tok({"\\X", "\\times"}) & G.Expression)^+
 
-      |       Tok({"WF_", "SF_"}) 
-           & G.Expression  
-           & tok("(") & G.Expression & tok(")") 
+   /\ G.StepExpressionOrStutter ::=
+            tok("[") & G.Expression & tok("]_") & G.SubscriptExpression
 
-      |       tok("IF")   & G.Expression 
-           & tok("THEN")  & G.Expression  
-           & tok("ELSE") & G.Expression 
+   /\ G.StepExpressionNoStutter ::=
+            tok("<<") & G.Expression & tok(">>_") & G.SubscriptExpression
 
-      |  tok("CASE") 
-         &  ( LET CaseArm == 
-                     G.Expression & tok("->") & G.Expression
+   /\ G.Fairness ::=
+            Tok({"WF_", "SF_"})
+         &  G.SubscriptExpression
+         &  tok("(") & G.Expression & tok(")")
+
+   /\ G.IfThenElse ::=
+            tok("IF")   & G.Expression
+         &  tok("THEN") & G.Expression
+         &  tok("ELSE") & G.Expression
+
+   /\ G.Case ::=
+            tok("CASE")
+         &  ( LET CaseArm == G.Expression & tok("->") & G.Expression
               IN  CaseArm & (tok("[]") & CaseArm)^* )
+         &  ( Nil | (tok("[]") & tok("OTHER") & tok("->") & G.Expression))
 
-         &  (      Nil 
-              |  (tok("[]") & tok("OTHER") & tok("->") & G.Expression)) 
+   /\ G.LetIn ::=
+            tok("LET")
+         &  (    G.OperatorDefinition
+              |  G.FunctionDefinition
+              |  G.ModuleDefinition
+              |  G.Recursive)^+
+         &  tok("IN")
+         &  G.Expression
 
-     |        tok("LET") 
-           &  (    G.OperatorDefinition 
-                |  G.FunctionDefinition 
-                |  G.ModuleDefinition
-                |  G.Recursive)^+
-           &  tok("IN") 
-           &  G.Expression
+   /\ G.ConjunctionList ::= (tok("/\\") & G.Expression)^+
 
-     |  (tok("/\\") & G.Expression)^+ 
-
-     |  (tok("\\/") & G.Expression)^+ 
-
-     |  Number 
-
-     |  String 
-
-     |  tok("@")
+   /\ G.DisjunctionList ::= (tok("\\/") & G.Expression)^+
 
 IN LeastGrammar(P)
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -154,18 +154,23 @@ TLAPlusGrammar ==
 
    /\ G.OpArgs ::= tok("(") & CommaList(G.OpOrExpression) & tok(")")
 
-   /\ G.InstOrSubexprPrefix ::=  
-      (    (Nil | ProofStepId & tok("!")) 
-        & ( (   Identifier & (Nil | G.OpArgs)
-              | Tok({"<<", ">>", ":"} \cup Numeral^+)
-              | G.OpArgs 
-              | (PrefixOp | PostfixOp) & tok("(") & G.Expression & tok(")")
-              | InfixOp & tok("(") & G.Expression & tok(",") 
-                  & G.Expression & tok(")")
-             )
-            &  tok("!")
-          ) ^*
-      ) \ Nil
+   /\ G.InstOrSubexprPrefix ::=
+           (G.SubexprComponent | ProofStepId) & tok("!")
+        &  ((G.SubexprComponent | G.SubexprTreeNav) & tok("!"))^*
+   
+   /\ G.SubexprComponent ::=
+           Identifier & (Nil | G.OpArgs)
+        |  PrefixOp & tok("(") & G.Expression & tok(")")
+        |  InfixOp & tok("(") & G.Expression & tok(",")
+             & G.Expression & tok(")")
+        |  PostfixOp & tok("(") & G.Expression & tok(")")
+        |  PrefixOp
+        |  InfixOp
+        |  PostfixOp
+
+   /\ G.SubexprTreeNav ::=
+           Tok({"<<", ">>", ":", "@"} \cup Numeral^+)
+        |  G.OpArgs
 
 \* /\ G.InstancePrefix ::= ...
 
@@ -266,9 +271,7 @@ TLAPlusGrammar ==
             Name & (Nil | tok("(") & CommaList(Identifier) & tok(")")) 
                & tok("::") & G.Expression
 
-         |  G.InstOrSubexprPrefix 
-               & (Tok({"<<", ">>", ":"} \cup Numeral^+) | G.OpArgs)
-
+         |  G.InstOrSubexprPrefix & G.SubexprTreeNav
 
          |  G.GeneralIdentifier & (Nil | G.OpArgs)
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -152,13 +152,6 @@ TLAPlusGrammar ==
    /\ G.Lambda ::= tok("LAMBDA") & CommaList(Identifier) 
                      & tok(":") & G.Expression
 
-   /\ G.OpName ::= 
-        (Identifier | PrefixOp | InfixOp | PostfixOp | ProofStepId)
-      & (  tok("!")
-         & (Identifier | PrefixOp | InfixOp | PostfixOp
-              | Tok({"<<", ">>", "@"} \cup Numeral^+) )
-        )^*
-
    /\ G.OpArgs ::= tok("(") & CommaList(G.OpOrExpression) & tok(")")
 
    /\ G.InstOrSubexprPrefix ::=  
@@ -261,7 +254,7 @@ TLAPlusGrammar ==
 
    /\ G.UseBody  ::=  (  (Nil | CommaList(G.Expression | tok("MODULE") & Name ))
                        & (Nil | Tok({"DEF", "DEFS"}) 
-                                  & CommaList(G.OpName | 
+                                  & CommaList(G.OpOrExpression | 
                                                 tok("MODULE") & Name ))
                       ) \ Nil
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -165,14 +165,19 @@ TLAPlusGrammar ==
         &  ((G.SubexprComponent | G.SubexprTreeNav) & tok("!"))^*
    
    /\ G.SubexprComponent ::=
-           Identifier & (Nil | G.OpArgs)
-        |  StandalonePrefixOp & tok("(") & G.Expression & tok(")")
-        |  InfixOp & tok("(") & G.Expression & tok(",")
-             & G.Expression & tok(")")
-        |  PostfixOp & tok("(") & G.Expression & tok(")")
+           G.BoundOp
+        |  G.BoundNonfixOp
         |  StandalonePrefixOp
         |  InfixOp
         |  PostfixOp
+
+   /\ G.BoundOp ::= Identifier & (Nil | G.OpArgs)
+
+   /\ G.BoundNonfixOp ::=
+           StandalonePrefixOp & tok("(") & G.Expression & tok(")")
+        |  InfixOp & tok("(") & G.Expression & tok(",")
+             & G.Expression & tok(")")
+        |  PostfixOp & tok("(") & G.Expression & tok(")")
 
    /\ G.SubexprTreeNav ::=
            Tok({"<<", ">>", ":", "@"} \cup Numeral^+)
@@ -182,8 +187,7 @@ TLAPlusGrammar ==
 
    /\ G.GeneralIdentifier ::=
            (Nil | G.InstOrSubexprPrefix)
-        &  Identifier
-        &  (Nil | G.OpArgs)
+        &  (G.BoundOp | G.BoundNonfixOp)
 
 \* /\ G.GeneralIdentifier ::= ...
 \* /\ G.GeneralPrefixOp   ::= ...
@@ -269,7 +273,6 @@ TLAPlusGrammar ==
                                   & CommaList(G.OpOrExpression | 
                                                 tok("MODULE") & Name ))
                       ) \ Nil
-
 
    /\ G.Expression ::= 
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -112,6 +112,7 @@ TLAPlusGrammar ==
                      |  PrefixOp & tok("_")
                      |  tok("_") & InfixOp & tok("_")
                      |  tok("_") & PostfixOp  
+
    /\  G.OperatorDefinition ::=  
             (   G.NonFixLHS 
              |  PrefixOp   & Identifier 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -146,7 +146,10 @@ TLAPlusGrammar ==
    /\ G.Substitution ::=  
              (Identifier | PrefixOp | InfixOp | PostfixOp ) 
           &  tok("<-") 
-          &  G.Argument  
+          &  G.OpOrExpression 
+
+   /\ G.OpOrExpression ::=
+          PrefixOp | InfixOp | PostfixOp | G.Lambda | G.Expression
 
    /\ G.Argument ::= G.Expression  | G.Opname | G.Lambda
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -49,9 +49,15 @@ BeginStepToken == Tok({"<"} & (Numeral^+ | {"*", "+"}) & {">"} &
 
 String == Tok({"\""} & STRING & {"\""})
 
+PrefixOpExceptNegative ==
+  { "~", "\\lnot", "\\neg", "[]", "<>",
+    "DOMAIN",  "ENABLED", "SUBSET", "UNCHANGED", "UNION"}
+
+StandalonePrefixOp ==
+  Tok(PrefixOpExceptNegative \cup {"-."})
+
 PrefixOp  ==  
-  Tok({ "-", "~", "\\lnot", "\\neg", "[]", "<>",
-        "DOMAIN",  "ENABLED", "SUBSET", "UNCHANGED", "UNION"})
+  Tok(PrefixOpExceptNegative \cup {"-"})
 
 InfixOp   ==
   Tok({  "!!",  "#",    "##",   "$",    "$$",   "%",    "%%",  
@@ -109,13 +115,13 @@ TLAPlusGrammar ==
    /\ G.OpDecl ::=      Identifier 
                      |  Identifier & tok("(") & 
                                CommaList(tok("_")) & tok(")")
-                     |  PrefixOp & tok("_")
+                     |  StandalonePrefixOp & tok("_")
                      |  tok("_") & InfixOp & tok("_")
                      |  tok("_") & PostfixOp  
 
    /\  G.OperatorDefinition ::=  
             (   G.NonFixLHS 
-             |  PrefixOp   & Identifier 
+             |  StandalonePrefixOp   & Identifier 
              |  Identifier & InfixOp & Identifier 
              |  Identifier & PostfixOp )
           &  tok("==") 
@@ -142,12 +148,12 @@ TLAPlusGrammar ==
         &  (Nil | tok("WITH") & CommaList(G.Substitution))  
 
    /\ G.Substitution ::=  
-             (Identifier | PrefixOp | InfixOp | PostfixOp ) 
+             (Identifier | StandalonePrefixOp | InfixOp | PostfixOp ) 
           &  tok("<-") 
           &  G.OpOrExpression 
 
    /\ G.OpOrExpression ::=
-          PrefixOp | InfixOp | PostfixOp | G.Lambda | G.Expression
+          StandalonePrefixOp | InfixOp | PostfixOp | G.Lambda | G.Expression
 
    /\ G.Lambda ::= tok("LAMBDA") & CommaList(Identifier) 
                      & tok(":") & G.Expression
@@ -160,11 +166,11 @@ TLAPlusGrammar ==
    
    /\ G.SubexprComponent ::=
            Identifier & (Nil | G.OpArgs)
-        |  PrefixOp & tok("(") & G.Expression & tok(")")
+        |  StandalonePrefixOp & tok("(") & G.Expression & tok(")")
         |  InfixOp & tok("(") & G.Expression & tok(",")
              & G.Expression & tok(")")
         |  PostfixOp & tok("(") & G.Expression & tok(")")
-        |  PrefixOp
+        |  StandalonePrefixOp
         |  InfixOp
         |  PostfixOp
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -180,9 +180,10 @@ TLAPlusGrammar ==
 
 \* /\ G.InstancePrefix ::= ...
 
-   /\ G.GeneralIdentifier ::= 
-           (G.InstOrSubexprPrefix | Nil) & Identifier 
-         | ProofStepId
+   /\ G.GeneralIdentifier ::=
+           (Nil | G.InstOrSubexprPrefix)
+        &  Identifier
+        &  (Nil | G.OpArgs)
 
 \* /\ G.GeneralIdentifier ::= ...
 \* /\ G.GeneralPrefixOp   ::= ...
@@ -279,7 +280,9 @@ TLAPlusGrammar ==
 
          |  G.InstOrSubexprPrefix & G.SubexprTreeNav
 
-         |  G.GeneralIdentifier & (Nil | G.OpArgs)
+         |  G.GeneralIdentifier
+
+         |  ProofStepId
 
          |  PrefixOp & G.Expression 
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -42,7 +42,7 @@ NumberLexeme ==
 
 Number == Tok(NumberLexeme)
 
-ProofStepId == Tok({"<"} & (Numeral^+ | {"*"}) & {">"} & (Letter | Numeral | {"_"})^+)
+ProofStepId == Tok({"<"} & (Numeral^+ | {"*"}) & {">"} & (Letter | Numeral)^+)
 
 BeginStepToken == Tok({"<"} & (Numeral^+ | {"*", "+"}) & {">"} & 
                        (Letter | Numeral)^* & {"."}^* )

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -383,7 +383,8 @@ TLAPlusGrammar ==
      |        tok("LET") 
            &  (    G.OperatorDefinition 
                 |  G.FunctionDefinition 
-                |  G.ModuleDefinition)^+ 
+                |  G.ModuleDefinition
+                |  G.Recursive)^+
            &  tok("IN") 
            &  G.Expression
 

--- a/grammar/TLAPlus2Grammar.tla
+++ b/grammar/TLAPlus2Grammar.tla
@@ -123,10 +123,7 @@ TLAPlusGrammar ==
 
    /\ G.NonFixLHS ::=   
              Identifier 
-          &  (    Nil 
-              |   tok("(") 
-                & CommaList(Identifier |  G.OpDecl) 
-                & tok(")") ) 
+          &  ( Nil | tok("(") & CommaList(G.OpDecl) & tok(")") )
 
    /\ G.FunctionDefinition ::=   
            Identifier  


### PR DESCRIPTION
These changes fix numerous issues with the existing TLA+2 BNF grammar spec, backporting a number of changes from the SANY parser and adding some missing rules. Changelist:

1. Restricted allowed syntax for `INSTANCE` substitutions
2. Allowed use of `RECURSIVE` operator declarations inside `LET-IN` constructs
3. Removed underscore from allowed characters in `ProofStepId`
4. Made large changes to `InstOrSubexprPrefix` rule to match SANY functioning
5. Encoded when to use `-` vs `-.` for the negative prefix operator
6. Separated `ProofStepId` from `GeneralIdentifier` rule
7. Added nonfix operators, for example `+(1,2)`
8. Broke up `Expression` rule to allow definition of `SubscriptExpression` rule